### PR TITLE
feature(Transitions) : cross-fading transition between scenes without…

### DIFF
--- a/src/main/java/game/adventurer/AdventurerGameApp.java
+++ b/src/main/java/game/adventurer/AdventurerGameApp.java
@@ -1,5 +1,7 @@
 package game.adventurer;
 
+import static game.adventurer.ui.common.SceneTransitionsManager.crossFadeTransition;
+
 import game.adventurer.common.SharedSize;
 import game.adventurer.exceptions.NoValidRangeException;
 import game.adventurer.model.GameMap;
@@ -26,6 +28,7 @@ public class AdventurerGameApp extends Application {
   private SharedSize sharedSize;
   private Stage primaryStage;
   private static final float INITIAL_SCREEN_SIZE_RATIO = 0.8f;
+  public static final String APP_NAME = "Adventurer Game";
   private static final Logger LOG = LoggerFactory.getLogger(AdventurerGameApp.class);
 
   @Override
@@ -45,14 +48,26 @@ public class AdventurerGameApp extends Application {
     primaryStage.setMinWidth(minWidth);
     primaryStage.setMinHeight(minHeight);
 
-    SplashScreen splashScreen = SplashScreen.create("Adventurer Game", sharedSize);
+    showSplashScreen();
+  }
+
+  private void showSplashScreen() {
+    SplashScreen splashScreen = SplashScreen.create(APP_NAME, sharedSize);
+
     primaryStage.setScene(splashScreen);
     primaryStage.show();
 
-    // Transition to the game scene after 3 seconds
-    PauseTransition delay = new PauseTransition(Duration.seconds(3));
-    delay.setOnFinished(event -> showPlayerSetup());
-    delay.play();
+    // Wait a bit before initiating transition
+    PauseTransition initialDelay = new PauseTransition(Duration.seconds(2));
+    initialDelay.setOnFinished(event -> {
+      // Creating next scene
+      PlayerSetupScene playerSetupScene = new PlayerSetupScene(sharedSize);
+      playerSetupScene.setOnStartGame(this::startGame);
+
+      // Cross dade transition to playerSetupScene
+      crossFadeTransition(primaryStage, playerSetupScene, Duration.seconds(0.5));
+    });
+    initialDelay.play();
   }
 
   private void showPlayerSetup() {
@@ -92,6 +107,5 @@ public class AdventurerGameApp extends Application {
     Platform.exit(); // Clean exit
     System.exit(0); // Even cleaner if background threads running or resources to free
   }
-
 
 }

--- a/src/main/java/game/adventurer/ui/common/BaseScene.java
+++ b/src/main/java/game/adventurer/ui/common/BaseScene.java
@@ -5,7 +5,9 @@ import game.adventurer.config.AppConfig;
 import java.util.Objects;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import lombok.Getter;
 
+@Getter
 public abstract class BaseScene extends Scene {
 
   protected final SharedSize sharedSize;

--- a/src/main/java/game/adventurer/ui/common/SceneTransitionsManager.java
+++ b/src/main/java/game/adventurer/ui/common/SceneTransitionsManager.java
@@ -1,0 +1,46 @@
+package game.adventurer.ui.common;
+
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
+import javafx.stage.Stage;
+import javafx.util.Duration;
+
+public class SceneTransitionsManager {
+
+  private SceneTransitionsManager() {
+  }
+
+
+  public static void crossFadeTransition(Stage stage, BaseScene newScene, Duration duration) {
+    BaseScene oldScene = (BaseScene) stage.getScene();
+
+    // Create a transitionScene
+    TransitionScene<BaseScene> transitionScene = new TransitionScene<>(oldScene.getSharedSize(), oldScene, newScene);
+
+    // Define the transition Stage as the current scene
+    stage.setScene(transitionScene);
+
+    // Create the cross-fading transition
+    Timeline timeline = new Timeline(
+        new KeyFrame(Duration.ZERO,
+            new KeyValue(oldScene.getRoot().opacityProperty(), 1.0),
+            new KeyValue(newScene.getRoot().opacityProperty(), 0.0)
+        ),
+        new KeyFrame(duration,
+            new KeyValue(oldScene.getRoot().opacityProperty(), 0.0),
+            new KeyValue(newScene.getRoot().opacityProperty(), 1.0)
+        )
+    );
+
+    timeline.setOnFinished(event ->
+            // remove the oldScene from the StackPane
+            transitionScene.removeOldScene()
+        // Lots of trouble setting the stage to the new scene. Let's keep it that way
+        // as the oldScene has been removed, it should not cause problems.
+    );
+
+    timeline.play();
+  }
+
+}

--- a/src/main/java/game/adventurer/ui/common/TransitionScene.java
+++ b/src/main/java/game/adventurer/ui/common/TransitionScene.java
@@ -1,0 +1,53 @@
+package game.adventurer.ui.common;
+
+import game.adventurer.common.SharedSize;
+import javafx.geometry.Pos;
+import javafx.scene.layout.StackPane;
+
+/**
+ * Represents a transition scene that blends two BaseScene instances for smooth visual transitions. This class extends BaseScene and uses a StackPane
+ * to overlay the old and new scenes.
+ *
+ * @param <T> The type of BaseScene this transition scene will handle.
+ */
+public class TransitionScene<T extends BaseScene> extends BaseScene {
+
+  private final T oldScene;
+  private final T newScene;
+
+  /**
+   * Constructs a new TransitionScene.
+   *
+   * @param sharedSize The shared size information for the scene.
+   * @param oldScene   The scene that is being transitioned from.
+   * @param newScene   The scene that is being transitioned to.
+   */
+  public TransitionScene(
+      SharedSize sharedSize, T oldScene, T newScene) {
+    super(new StackPane(), sharedSize);
+    this.oldScene = oldScene;
+    this.newScene = newScene;
+    initialize();
+  }
+
+  @Override
+  protected void initialize() {
+    newScene.getRoot().setOpacity(0.0); // avoids a visual glitch (with Scene set at opacity 1.0 briefly then put to 0.0)
+
+    // Create a StackPane to contain both scenes
+    StackPane root = (StackPane) getRoot();
+    root.getChildren().addAll(oldScene.getRoot(), newScene.getRoot());
+
+    // Ensure both scenes take all available space
+    StackPane.setAlignment(oldScene.getRoot(), Pos.CENTER);
+    StackPane.setAlignment(newScene.getRoot(), Pos.CENTER);
+  }
+
+  /**
+   * Removes the old scene from this transition scene. This method should be called after the transition is complete.
+   */
+  public void removeOldScene() {
+    StackPane root = (StackPane) getRoot();
+    root.getChildren().remove(oldScene.getRoot());
+  }
+}


### PR DESCRIPTION
… having a white flash (stage with no visible scene) between them

- creation of a SceneTransitionsManager to handle transitions between Scenes;
- as cross-fade transition between scenes always happened to produce a (brief) white screen as the primaryStage had no scene rendered for an instant (opacity of oldScene at 0.0 and newScene at 0.0), creation of a "TransitionScene" extending BaseScene, which stacks the old and the new Scenes on initialize() and contains a method to remove the old Scene when it's not needed anymore.