### PR TITLE
feature: Field of View by modified Bresenham line algorithm

### DIFF
--- a/src/main/java/game/adventurer/model/Adventurer.java
+++ b/src/main/java/game/adventurer/model/Adventurer.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @Getter
 public class Adventurer extends Creature {
 
+  // TODO : overload the facing direction so it's not random for the Adventurer but opposing it's side of the Map
+
   public Adventurer(String name, int tileX, int tileY, int health, int moveSpeed) {
     super(name, tileX, tileY, health, moveSpeed);
   }

--- a/src/main/java/game/adventurer/model/GameMap.java
+++ b/src/main/java/game/adventurer/model/GameMap.java
@@ -6,6 +6,7 @@ import game.adventurer.exceptions.InvalidGameStateException;
 import game.adventurer.model.Tile.Type;
 import game.adventurer.model.base.Creature;
 import game.adventurer.model.base.Wound;
+import game.adventurer.model.enums.Move;
 import game.adventurer.model.enums.MoveResult;
 import game.adventurer.model.enums.WoundCause;
 import game.adventurer.service.LocalizedMessageService;
@@ -38,7 +39,7 @@ public class GameMap {
     this.woundsList = new ArrayList<>();
   }
 
-  public MoveResult moveAdventurer(int dx, int dy) {
+  public MoveResult moveAdventurer(Move move) {
     try {
       if (isOutOfMapBounds(adventurer.getTileX(), adventurer.getTileY())) {
         LOG.error("Adventurer's current coordinates ({}, {}) are invalid!",
@@ -48,8 +49,8 @@ public class GameMap {
     } catch (InvalidGameStateException e) {
       handleInvalidGameState(getClass(), e);
     }
-    int newX = adventurer.getTileX() + dx;
-    int newY = adventurer.getTileY() + dy;
+    int newX = adventurer.getTileX() + move.getDx();
+    int newY = adventurer.getTileY() + move.getDy();
 
     // First, check if the move is within the map bounds
     if (isOutOfMapBounds(newX, newY)) {
@@ -75,7 +76,7 @@ public class GameMap {
     }
 
     // If everything else is ok, try to proceed with the move.
-    boolean hasMoved = adventurer.move(dx, dy);
+    boolean hasMoved = adventurer.move(move);
     // If move call wasn't too early, the Adventurer shall move, else return BLOCKED
     return hasMoved ? MoveResult.MOVED : MoveResult.BLOCKED;
   }
@@ -87,6 +88,30 @@ public class GameMap {
       }
       case Monster ignored -> {
         return x >= 0 && x < mapWidth && y >= 0 && y < mapHeight;
+      }
+      default -> {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Checks if a given position is valid for a specific creature on the game map.
+   *
+   * <p>The validity of a position depends on the type of creature.
+   *
+   * @param position The position to check for validity.
+   * @param creature The creature for which the position is being checked.
+   * @return true if the position is valid for the given creature, false otherwise.
+   */
+  public boolean isValidPosition(Position position, Creature creature) {
+    switch (creature) {
+      case Adventurer ignored -> {
+        return position.x() >= 0 && position.x() < mapWidth && position.y() >= 0 && position.y() < mapHeight
+            && getTileTypeAt(position.x(), position.y()) == Type.PATH;
+      }
+      case Monster ignored -> {
+        return position.x() >= 0 && position.x() < mapWidth && position.y() >= 0 && position.y() < mapHeight;
       }
       default -> {
         return false;

--- a/src/main/java/game/adventurer/model/Position.java
+++ b/src/main/java/game/adventurer/model/Position.java
@@ -1,0 +1,18 @@
+package game.adventurer.model;
+
+
+import game.adventurer.model.enums.Direction;
+
+
+public record Position(int x, int y) {
+
+  public Position move(Direction direction) {
+    return switch (direction) {
+      case NORTH -> new Position(x, y - 1);
+      case SOUTH -> new Position(x, y + 1);
+      case WEST -> new Position(x - 1, y);
+      case EAST -> new Position(x + 1, y);
+    };
+  }
+
+}

--- a/src/main/java/game/adventurer/model/base/Creature.java
+++ b/src/main/java/game/adventurer/model/base/Creature.java
@@ -1,5 +1,8 @@
 package game.adventurer.model.base;
 
+import game.adventurer.model.enums.Direction;
+import game.adventurer.model.enums.Move;
+import java.util.Random;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import lombok.Getter;
@@ -19,6 +22,7 @@ public abstract class Creature {
   protected long lastMoveTime = 0;
   protected int previousTileX;
   protected int previousTileY;
+  protected Direction facingDirection;
 
   private static final int DEFAULT_HEALTH = 10;
   private static final int DEFAULT_MOVE_SPEED = 1;
@@ -30,6 +34,7 @@ public abstract class Creature {
     this.tileY = tileY;
     this.health = new SimpleIntegerProperty(health);
     this.moveSpeed = moveSpeed;
+    this.facingDirection = Direction.values()[new Random().nextInt(Direction.values().length)]; // creates a random facing Direction
   }
 
   protected Creature(String name, int tileX, int tileY) {
@@ -51,13 +56,13 @@ public abstract class Creature {
     this.health.set(health);
   }
 
-  public boolean move(int dx, int dy) {
+  public boolean move(Move move) {
     long currentTime = System.currentTimeMillis();
     if (lastMoveTime + 300 < currentTime) {
       this.previousTileX = this.tileX;
       this.previousTileY = this.tileY;
-      this.tileX += dx;
-      this.tileY += dy;
+      this.tileX += move.getDx();
+      this.tileY += move.getDy();
       lastMoveTime = currentTime;
       return true;
     }

--- a/src/main/java/game/adventurer/model/enums/Direction.java
+++ b/src/main/java/game/adventurer/model/enums/Direction.java
@@ -1,0 +1,38 @@
+package game.adventurer.model.enums;
+
+public enum Direction {
+  NORTH {
+    @Override
+    public Direction getOpposite() {
+      return SOUTH;
+    }
+  },
+  SOUTH {
+    @Override
+    public Direction getOpposite() {
+      return NORTH;
+    }
+  },
+  EAST {
+    @Override
+    public Direction getOpposite() {
+      return WEST;
+    }
+  },
+  WEST {
+    @Override
+    public Direction getOpposite() {
+      return EAST;
+    }
+  };
+
+  public abstract Direction getOpposite();
+
+  public Direction turnClockwise() {
+    return values()[(this.ordinal() + 1) % values().length];
+  }
+
+  public Direction turnCounterClockwise() {
+    return values()[(this.ordinal() - 1 + values().length) % values().length];
+  }
+}

--- a/src/main/java/game/adventurer/model/enums/Move.java
+++ b/src/main/java/game/adventurer/model/enums/Move.java
@@ -1,0 +1,21 @@
+package game.adventurer.model.enums;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public enum Move {
+  UP(0, -1),
+  DOWN(0, 1),
+  LEFT(-1, 0),
+  RIGHT(1, 0);
+
+  private final int dx;
+  private final int dy;
+
+  Move(int dx, int dy) {
+    this.dx = dx;
+    this.dy = dy;
+  }
+}

--- a/src/main/java/game/adventurer/util/MiscUtil.java
+++ b/src/main/java/game/adventurer/util/MiscUtil.java
@@ -2,7 +2,16 @@ package game.adventurer.util;
 
 import game.adventurer.config.AppConfig;
 import game.adventurer.exceptions.InvalidGameStateException;
+import game.adventurer.model.Adventurer;
+import game.adventurer.model.GameMap;
+import game.adventurer.model.Monster;
+import game.adventurer.model.Position;
+import game.adventurer.model.Tile.Type;
+import game.adventurer.model.base.Creature;
+import game.adventurer.model.enums.Direction;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -111,5 +120,177 @@ public class MiscUtil {
       Platform.exit(); // Clean exit
       System.exit(0);
     });
+  }
+
+
+  /**
+   * Calculates the field of view for a creature on the game map using a modified Bresenham's line algorithm. This method determines which tiles are
+   * visible to the creature based on its position and the map layout.
+   *
+   * @param creature The creature for which to calculate the field of view.
+   * @param gameMap  The game map containing the tiles and obstacles.
+   * @return A set of Position objects representing the visible tiles.
+   */
+  public static Set<Position> calculateFieldOfView(Creature creature, GameMap gameMap) {
+    Set<Position> visibleTiles = new HashSet<>();
+    Position origin = new Position(creature.getTileX(), creature.getTileY());
+    visibleTiles.add(origin); // The creature's position is always "visible" to her
+
+    // TODO: update when new Creatures are ... created, hehe
+    int maxDistance = switch (creature) {
+      case Adventurer ignored -> 5; // 5 as 5 is the max an Adventurer can "see" in the best direction (frontward)
+      case Monster ignored -> 8;
+      default -> throw new IllegalStateException("Unexpected value: " + creature);
+    };
+
+    // Iterate through all tiles within the maximum view distance
+    for (int dx = -maxDistance; dx <= maxDistance; dx++) {
+      for (int dy = -maxDistance; dy <= maxDistance; dy++) {
+        if (dx == 0 && dy == 0) {
+          continue; // Skip the creature's own position
+        }
+
+        Position targetPosition = new Position(origin.x() + dx, origin.y() + dy);
+        // Check if the target position is within the map boundaries
+        if (isOutOfMapBounds(gameMap, targetPosition.x(), targetPosition.y())) {
+          continue;
+        }
+        // Check if the target is visible and within the creature's view distance
+        if (isVisible(origin, targetPosition, gameMap) &&
+            getDistance(origin, targetPosition) <= getMaxVisibleDistanceForCreature(targetPosition, origin, creature)) {
+          visibleTiles.add(targetPosition);
+        }
+      }
+    }
+
+    return visibleTiles;
+  }
+
+  /**
+   * Determines if a target position is visible from an origin position using a modified Bresenham's line algorithm. This method takes into account
+   * obstacles (WOOD tiles) and checks for diagonal visibility.
+   *
+   * @param origin  The starting position.
+   * @param target  The target position to check for visibility.
+   * @param gameMap The game map containing the tiles and obstacles.
+   * @return true if the target is visible from the origin, false otherwise.
+   */
+  private static boolean isVisible(Position origin, Position target, GameMap gameMap) {
+    int originX = origin.x();
+    int originY = origin.y();
+    int targetX = target.x();
+    int targetY = target.y();
+    int deltaX = Math.abs(targetX - originX);
+    int deltaY = Math.abs(targetY - originY);
+    int stepX = originX < targetX ? 1 : -1;
+    int stepY = originY < targetY ? 1 : -1;
+    int error = deltaX - deltaY;
+
+    // keep going until we reached target from origin, unless we return a boolean on the way
+    while (originX != targetX || originY != targetY) {
+      // Check if the current position is within map boundaries, also protects usage of getTileTypeAt() from a potential out of bounds exception
+      if (isOutOfMapBounds(gameMap, originX, originY)) {
+        return false;
+      }
+      // Check if the current tile is blocking (WOOD)
+      if (gameMap.getTileTypeAt(originX, originY) == Type.WOOD) {
+        return false;
+      }
+
+      // Check for diagonal visibility
+      if (originX != targetX && originY != targetY) {
+        // We're moving diagonally
+        boolean horizontalBlocked = gameMap.getTileTypeAt(originX + stepX, originY) == Type.WOOD;
+        boolean verticalBlocked = gameMap.getTileTypeAt(originX, originY + stepY) == Type.WOOD;
+
+        // If both adjacent directions are blocked, block the diagonal
+        if (horizontalBlocked && verticalBlocked) {
+          return false;
+        }
+      }
+
+      // Bresenham's line algorithm core
+      int doubledError = 2 * error; // this way we never use float numbers
+      if (doubledError > -deltaY) { // should "pixel" be "moved" horizontally?
+        error -= deltaY; // then adjust error
+        originX += stepX; // and increment originX in the appropriate direction
+      }
+      if (doubledError < deltaX) { // should "pixel" be "moved" vertically?
+        error += deltaX;
+        originY += stepY;
+      }
+    }
+
+    return true; // The target is visible
+  }
+
+
+  /**
+   * Calculates the Manhattan distance between two positions.
+   *
+   * @param p1 The first position.
+   * @param p2 The second position.
+   * @return The Manhattan distance between the two positions.
+   */
+  private static int getDistance(Position p1, Position p2) {
+    return Math.abs(p1.x() - p2.x()) + Math.abs(p1.y() - p2.y());
+  }
+
+  /**
+   * Determines the maximum visible distance for a creature based on its facing direction and the direction to the target.
+   *
+   * @param currentlyCheckedPosition The position being checked for visibility.
+   * @param startPosition            The starting position of the creature.
+   * @param creature                 The creature whose field of view is being calculated.
+   * @return The maximum distance the creature can see in the direction of the checked position.
+   */
+  private static int getMaxVisibleDistanceForCreature(Position currentlyCheckedPosition, Position startPosition, Creature creature) {
+    Direction facingDirection = creature.getFacingDirection();
+
+    Direction currentDirection = getDirectionBetween(startPosition, currentlyCheckedPosition);
+    switch (creature) {
+      case Adventurer ignored -> {
+        if (currentDirection == facingDirection) {
+          return 5; // Frontward
+        } else if (currentDirection == facingDirection.getOpposite()) {
+          return 3; // Backward
+        } else {
+          return 4; // Sides
+        }
+      }
+      default -> {
+        return -1;
+      }
+    }
+  }
+
+  /**
+   * Determines the primary direction between two positions.
+   *
+   * @param start The starting position.
+   * @param end   The ending position.
+   * @return The primary direction (NORTH, SOUTH, EAST, or WEST) from start to end.
+   */
+  private static Direction getDirectionBetween(Position start, Position end) {
+    int dx = end.x() - start.x();
+    int dy = end.y() - start.y();
+
+    if (Math.abs(dx) > Math.abs(dy)) {
+      return dx > 0 ? Direction.EAST : Direction.WEST;
+    } else {
+      return dy > 0 ? Direction.SOUTH : Direction.NORTH;
+    }
+  }
+
+  /**
+   * Checks if a given coordinate is outside the boundaries of the game map.
+   *
+   * @param gameMap The game map to check against.
+   * @param x       The x-coordinate to check.
+   * @param y       The y-coordinate to check.
+   * @return true if the coordinate is out of bounds, false otherwise.
+   */
+  public static boolean isOutOfMapBounds(GameMap gameMap, int x, int y) {
+    return x < 0 || x >= gameMap.getMapWidth() || y < 0 || y >= gameMap.getMapHeight();
   }
 }


### PR DESCRIPTION
- Creation of the Direction Enum
- the Creatures now have a facingDirection set randomly at initialization
  - that shall be changed later on for the Adventurer type of Creature, that should face the opposite direction from its location side of the gameMap.
- Creation of the Position record class to store positions
- Creation of the Move Enum for better control over moves
- Adaptation of the GameMapTest class to handle the new Move

- new MiscUtil.calculateFieldOfView method to calculate the Field of View of Creatures, using a modified Bresenham algorithm to determinate which tiles are visible to the Creature;

- changes in MainGameScene to handle to change of visible Tile (of Type.PATH), and the change of Direction of the Adventurer when a key associated with a move is stroke;