### PR TITLE
Feature/sprinkle the map with monsters

### DIFF
--- a/src/main/java/game/adventurer/AdventurerGameApp.java
+++ b/src/main/java/game/adventurer/AdventurerGameApp.java
@@ -104,7 +104,7 @@ public class AdventurerGameApp extends Application {
 
   private void startGame(String playerName, MapSize mapSize, DifficultyLevel difficultyLevel) {
     try {
-      GameMap gameMap = MapGenerator.generateMap(mapSize.getSize(), mapSize.getSize(), playerName);
+      GameMap gameMap = MapGenerator.generateMap(playerName, mapSize, difficultyLevel);
       MainGameScene mainGameScene = MainGameScene.create(gameMap, sharedSize, difficultyLevel, localizationService, hostServices);
       mainGameScene.setOnGameEnd(() -> {
         mainGameScene.stopActiveTimelines();

--- a/src/main/java/game/adventurer/model/creature/Monster.java
+++ b/src/main/java/game/adventurer/model/creature/Monster.java
@@ -72,7 +72,7 @@ public abstract class Monster extends Creature {
     Position nextValidNeighbor = getValidNeighbor(this, gameMap, true);
     if (nextValidNeighbor != null) {
       searchArea.remove(nextValidNeighbor);
-      log.info("goes to nextValidNeigbor in {}, searchArea size : {}", nextValidNeighbor, searchArea.size());
+      log.info("{} goes to nextValidNeighbor in {}, searchArea size : {}", this.name, nextValidNeighbor, searchArea.size());
       moveTo(nextValidNeighbor);
     } else {
       if (searchTarget == null) {
@@ -89,7 +89,7 @@ public abstract class Monster extends Creature {
         }
         if (!nextPosition.equals(currentPosition)) {
           searchArea.remove(nextPosition);
-          log.info("searchArea size : {}", searchArea.size());
+          log.info("searchArea size : {} for {}", searchArea.size(), this.name);
           this.setSearchTarget(nextPosition);
         }
       } else {
@@ -103,7 +103,7 @@ public abstract class Monster extends Creature {
           searchArea.remove(path.getFirst());
 
           if (new Position(this.tileX, this.tileY).equals(searchTarget)) {
-            log.info("searchTarget {} reached, searchArea size: {}", searchTarget, searchArea.size());
+            log.info("{} : searchTarget {} reached, searchArea size: {}", this.name, searchTarget, searchArea.size());
             setSearchTarget(null);
           }
         }
@@ -236,5 +236,29 @@ public abstract class Monster extends Creature {
     this.setFacingDirection(facingDirection);
     lastMoveTime = System.currentTimeMillis();
 
+  }
+
+  @Override
+  public String toString() {
+    return "Monster{" +
+        "name='" + name + '\'' +
+        ", status=" + status +
+        ", baseDamages=" + baseDamages +
+        ", random=" + random +
+        ", lastSeenAdventurerPosition=" + lastSeenAdventurerPosition +
+        ", searchArea=" + searchArea +
+        ", searchTarget=" + searchTarget +
+        ", storedFOV=" + storedFOV +
+        ", tileX=" + tileX +
+        ", tileY=" + tileY +
+        ", health=" + health +
+        ", moveSpeed=" + moveSpeed +
+        ", lastMoveTime=" + lastMoveTime +
+        ", previousTileX=" + previousTileX +
+        ", previousTileY=" + previousTileY +
+        ", allowedTileTypes=" + allowedTileTypes +
+        ", facingDirection=" + facingDirection +
+        ", visibleTiles=" + visibleTiles +
+        '}';
   }
 }

--- a/src/main/java/game/adventurer/service/MapGenerator.java
+++ b/src/main/java/game/adventurer/service/MapGenerator.java
@@ -1,5 +1,11 @@
 package game.adventurer.service;
 
+import static game.adventurer.model.enums.DifficultyLevel.EASY;
+import static game.adventurer.model.enums.DifficultyLevel.HARD;
+import static game.adventurer.model.enums.DifficultyLevel.NORMAL;
+import static game.adventurer.model.enums.MapSize.LARGE;
+import static game.adventurer.model.enums.MapSize.MEDIUM;
+import static game.adventurer.model.enums.MapSize.SMALL;
 import static game.adventurer.util.PathfindingUtil.hasPath;
 
 import game.adventurer.exceptions.NoValidRangeException;
@@ -10,6 +16,8 @@ import game.adventurer.model.Tile.Type;
 import game.adventurer.model.Treasure;
 import game.adventurer.model.creature.Adventurer;
 import game.adventurer.model.creature.Lurker;
+import game.adventurer.model.enums.DifficultyLevel;
+import game.adventurer.model.enums.MapSize;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.random.RandomGenerator;
@@ -114,6 +122,65 @@ public class MapGenerator {
     }
 
     return map;
+  }
+
+  // TODO: finish it and use it in AdventurerGameApp or rework generateMap to use the Difficulty level and MapSize
+  private void addMonsters(GameMap map, MapSize size, DifficultyLevel difficultyLevel) {
+    record ChosenSettings(MapSize size, DifficultyLevel difficultyLevel) {
+
+    }
+    int lurkersCount = 0;
+    int muggersCount = 0;
+    int sniffersCount = 0;
+    ChosenSettings chosenSettings = new ChosenSettings(size, difficultyLevel);
+
+    // no record destructuration on enums in a switch in java 21, yet.
+    switch (chosenSettings) {
+      case ChosenSettings s when s.equals(new ChosenSettings(SMALL, EASY)) -> muggersCount = 2;
+      case ChosenSettings s when s.equals(new ChosenSettings(SMALL, NORMAL)) -> {
+        muggersCount = 1;
+        sniffersCount = 1;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(SMALL, HARD)) -> {
+        muggersCount = 1;
+        sniffersCount = 1;
+        lurkersCount = 1;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(MEDIUM, EASY)) -> {
+        muggersCount = 3;
+        sniffersCount = 1;
+        lurkersCount = 1;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(MEDIUM, NORMAL)) -> {
+        muggersCount = 3;
+        sniffersCount = 2;
+        lurkersCount = 1;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(MEDIUM, HARD)) -> {
+        muggersCount = 4;
+        sniffersCount = 2;
+        lurkersCount = 2;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(LARGE, EASY)) -> {
+        muggersCount = 6;
+        sniffersCount = 3;
+        lurkersCount = 3;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(LARGE, NORMAL)) -> {
+        muggersCount = 8;
+        sniffersCount = 5;
+        lurkersCount = 3;
+      }
+      case ChosenSettings s when s.equals(new ChosenSettings(LARGE, HARD)) -> {
+        muggersCount = 10;
+        sniffersCount = 6;
+        lurkersCount = 4;
+      }
+      case null, default -> throw new IllegalStateException("Unexpected settings: " + chosenSettings);
+    }
+
+    // loops for adding monsters to the map.
+    // the monsters should be placed on tiles that have the right to be on, have a path to the Adventurer (except Lurkers ?) and far enough from the Adventurer
   }
 
   private static boolean checkPath(GameMap gameMap, Adventurer adventurer, Treasure treasure) {

--- a/src/main/java/game/adventurer/service/MonsterPlacerService.java
+++ b/src/main/java/game/adventurer/service/MonsterPlacerService.java
@@ -1,0 +1,230 @@
+package game.adventurer.service;
+
+import game.adventurer.model.CreatureMovementHandler;
+import game.adventurer.model.GameMap;
+import game.adventurer.model.Position;
+import game.adventurer.model.Tile;
+import game.adventurer.model.Tile.Type;
+import game.adventurer.model.creature.Lurker;
+import game.adventurer.model.creature.Monster;
+import game.adventurer.model.creature.MovementHandler;
+import game.adventurer.model.creature.Mugger;
+import game.adventurer.model.creature.Sniffer;
+import game.adventurer.model.enums.MapSize;
+import game.adventurer.util.PathfindingUtil;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service class responsible for placing monsters on the game map.
+ */
+@Slf4j
+public class MonsterPlacerService {
+
+  private final GameMap map;
+  private final int mapWidth;
+  private final int mapHeight;
+  private final int quadrantsCount;
+  private final Random random = new Random();
+  /**
+   * By design, quadrants contain 25 Tile (or Position).
+   * <p>
+   * This allows more control and works perfectly fine on a square map where sides' length is a multiple of 5. It might need some rework if this were
+   * to change.
+   */
+  private static final int POSITIONS_PER_QUADRANT = 25;
+
+  public MonsterPlacerService(GameMap map, MapSize mapSize) {
+    this.map = map;
+    this.mapHeight = map.getMapHeight();
+    this.mapWidth = map.getMapWidth();
+    this.quadrantsCount = (int) (Math.pow(mapSize.getSize(), 2) / POSITIONS_PER_QUADRANT); // Dynamic quadrant count based on map size
+  }
+
+  /**
+   * Places monsters on the game map according to the specified quota for each monster type.
+   * <p>
+   * Monsters cannot be placed on an already occupied tile, <br/>they will be placed semi-randomly <br/>(randomly amongst the least populated
+   * quadrants of the map, <br/> and according to rules depending on the Monster's subclass).
+   *
+   * @param monsterQuotaMap A map containing the monster class and the number of monsters to place.
+   */
+  public void placeMonsters(Map<Class<? extends Monster>, Integer> monsterQuotaMap) {
+
+    List<Integer> availableQuadrants = getAvailableQuadrants();
+
+    // Map to track occupied positions per quadrant
+    Map<Integer, Set<Position>> occupiedPositions = new HashMap<>();
+
+    for (int quadrant : availableQuadrants) {
+      occupiedPositions.put(quadrant, new HashSet<>());
+    }
+
+    monsterQuotaMap.forEach((monsterClass, count) -> {
+
+      CreatureMovementHandler movementHandler = new CreatureMovementHandler(map);
+
+      for (int i = 0; i < count; i++) {
+
+        Position position = null;
+        int selectedQuadrant;
+
+        while (position == null && !occupiedPositions.isEmpty()) {
+          // Find quadrant with the least Monsters, or if several have the same population, one of them is randomly chosen.
+          selectedQuadrant = findLeastPopulatedQuadrant(occupiedPositions);
+          do {
+            // Find a valid and unoccupied Position for this monster
+            position = getValidPositionInQuadrant(selectedQuadrant, monsterClass);
+          } while (occupiedPositions.get(selectedQuadrant).contains(position));
+
+          if (position == null) {
+            // no valid and unoccupied Position was found: remove this quadrant from the map for next iteration
+            occupiedPositions.remove(selectedQuadrant);
+          } else {
+            // a new valid unoccupied Position was found, add it to the occupied ones
+            occupiedPositions.get(selectedQuadrant).add(position);
+          }
+        }
+
+        if (position == null) {
+          log.warn("No valid position found for monster {} after checking all quadrants", monsterClass.getSimpleName());
+          continue; // Skip this monster if no valid position is found
+        }
+
+        // Uses reflection to build the monster with the correct constructor.
+        try {
+          Constructor<? extends Monster> constructor = monsterClass.getDeclaredConstructor(String.class, int.class, int.class,
+              MovementHandler.class);
+          Monster monster = constructor.newInstance(monsterClass.getSimpleName() + " " + (i + 1), position.x(), position.y(), movementHandler);
+          map.addMonster(monster);
+
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    });
+
+
+  }
+
+  /**
+   * Returns the quadrant number for the specified coordinates.
+   *
+   * @param x The x-coordinate.
+   * @param y The y-coordinate.
+   * @return The quadrant number.
+   */
+  private int getQuadrant(int x, int y) {
+    int quadrantsPerRow = (int) Math.sqrt(quadrantsCount);
+    int quadrantWidth = mapWidth / quadrantsPerRow;
+    int quadrantHeight = mapHeight / quadrantsPerRow;
+    int quadrantX = x / quadrantWidth;
+    int quadrantY = y / quadrantHeight;
+    return quadrantY * quadrantsPerRow + quadrantX + 1;
+  }
+
+  /**
+   * Returns a list of available quadrants, excluding the quadrant where the adventurer is located.
+   *
+   * @return A list of available quadrant numbers.
+   */
+  private List<Integer> getAvailableQuadrants() {
+    int adventurerX = map.getAdventurer().getTileX();
+    int adventurerY = map.getAdventurer().getTileY();
+
+    int adventurerQuadrant = getQuadrant(adventurerX, adventurerY);
+    List<Integer> availableQuadrants = new ArrayList<>();
+    for (int i = 1; i <= quadrantsCount; i++) {
+      if (i != adventurerQuadrant) {
+        availableQuadrants.add(i);
+      }
+    }
+    return availableQuadrants;
+  }
+
+  /**
+   * Finds the least populated quadrant from the given map of occupied positions.
+   *
+   * @param occupiedPositionsPerQuadrant A map of occupied positions per quadrant.
+   * @return The number of the least populated quadrant, or a random quadrant's number amongst the less populated ones.
+   */
+  private int findLeastPopulatedQuadrant(Map<Integer, Set<Position>> occupiedPositionsPerQuadrant) {
+    int minCount = Integer.MAX_VALUE;
+    List<Integer> leastPopulatedQuadrants = new ArrayList<>();
+
+    for (Map.Entry<Integer, Set<Position>> entry : occupiedPositionsPerQuadrant.entrySet()) {
+      int quadrant = entry.getKey();
+      int count = entry.getValue().size();
+
+      if (count < minCount) {
+        minCount = count;
+        leastPopulatedQuadrants.clear();
+        leastPopulatedQuadrants.add(quadrant);
+      } else if (count == minCount) {
+        leastPopulatedQuadrants.add(quadrant);
+      }
+    }
+
+    // Returns a random quadrants amongst the less populated ones
+    return leastPopulatedQuadrants.get(random.nextInt(leastPopulatedQuadrants.size()));
+  }
+
+  /**
+   * Returns a valid position within the specified quadrant for the given monster class.
+   *
+   * @param quadrant     The quadrant number.
+   * @param monsterClass The class of the monster.
+   * @return A valid position within the quadrant, or {@code null} if none are valid.
+   */
+  private Position getValidPositionInQuadrant(int quadrant, Class<? extends Monster> monsterClass) {
+    int quadrantsPerRow = (int) Math.sqrt(quadrantsCount);
+    int quadrantWidth = mapWidth / quadrantsPerRow;
+    int quadrantHeight = mapHeight / quadrantsPerRow;
+    int quadrantX = (quadrant - 1) % quadrantsPerRow;
+    int quadrantY = (quadrant - 1) / quadrantsPerRow;
+
+    Set<Position> invalidPositions = new HashSet<>();
+
+    while (invalidPositions.size() < POSITIONS_PER_QUADRANT) {
+      int x = random.nextInt(quadrantX * quadrantWidth, (quadrantX + 1) * quadrantWidth);
+      int y = random.nextInt(quadrantY * quadrantHeight, (quadrantY + 1) * quadrantHeight);
+
+      Tile.Type type = map.getTileTypeAt(x, y);
+      if (isValidTileForMonster(type, monsterClass, x, y)) {
+        return new Position(x, y);
+      }
+      invalidPositions.add(new Position(x, y));
+    }
+    return null;
+  }
+
+  /**
+   * Checks if the specified tile type is valid for the given monster class at the specified coordinates.
+   *
+   * @param type         The tile type.
+   * @param monsterClass The class of the monster, extending the abstract {@code Monster} class.
+   * @param x            The x-coordinate.
+   * @param y            The y-coordinate.
+   * @return True if the tile is valid for the monster, false otherwise.
+   */
+  private boolean isValidTileForMonster(Tile.Type type, Class<? extends Monster> monsterClass, int x, int y) {
+    if (monsterClass == Lurker.class) {
+      return type == Tile.Type.WOOD;
+    } else if (monsterClass == Sniffer.class || monsterClass == Mugger.class) {
+      return type == Tile.Type.PATH && PathfindingUtil.hasPath(x, y, map.getAdventurer().getTileX(), map.getAdventurer().getTileY(), mapWidth,
+          mapHeight, (currentX, currentY) -> map.getTileTypeAt(currentX, currentY) == Type.PATH);
+    } else {
+      log.warn("Unexpected Monster class : {}", monsterClass.getSimpleName());
+    }
+    return false;
+  }
+
+}

--- a/src/main/java/game/adventurer/ui/MainGameScene.java
+++ b/src/main/java/game/adventurer/ui/MainGameScene.java
@@ -109,7 +109,6 @@ public class MainGameScene extends BaseScene implements Localizable {
 
   private Circle adventurerCircle;
   private Group treasureCross;
-  private TriangleCreatureRepresentation testMonsterRepresentation;
   @Getter
   private double tileSize;
   @Getter
@@ -458,9 +457,12 @@ public class MainGameScene extends BaseScene implements Localizable {
     // Set Adventurer field of View visually
     updateAdventurerFieldOfView();
 
-    // displays/hide testMonsterRepresentation
-    Position monsterPos = new Position(gameMap.getMonsters().getFirst().getTileX(), gameMap.getMonsters().getFirst().getTileY());
-    testMonsterRepresentation.setVisible(visibleTiles.contains(monsterPos));
+    // displays/hide the Monster representation based on the Adventurer FoV
+    for (Monster monster : gameMap.getMonsters()) {
+      Position monsterPos = new Position(monster.getTileX(), monster.getTileY());
+      creaturesRepresentationMap.get(monster).setVisible(visibleTiles.contains(monsterPos));
+    }
+
   }
 
   /**
@@ -630,27 +632,26 @@ public class MainGameScene extends BaseScene implements Localizable {
       }
     }
 
-    // Adding testMonsterRepresentation
-    testMonsterRepresentation = new TriangleCreatureRepresentation(tileSize * 0.9, gameMap.getMonsters().getFirst().getFacingDirection());
-    double maDvX = xOffset + (gameMap.getMonsters().getFirst().getTileX() + 0.5) * tileSize;
-    double maDvY = yOffset + (gameMap.getMonsters().getFirst().getTileY() + 0.5) * tileSize;
+    // Adding Monsters representations
+    for (Monster monster : gameMap.getMonsters()) {
+      TriangleCreatureRepresentation monsterRender = new TriangleCreatureRepresentation(tileSize * 0.9, monster.getFacingDirection());
+      double maDvX = xOffset + (monster.getTileX() + 0.5) * tileSize;
+      double maDvY = yOffset + (monster.getTileY() + 0.5) * tileSize;
 
-    // Move the triangle to (maDvX, maDvY)
-    testMonsterRepresentation.setLayoutX(maDvX);
-    testMonsterRepresentation.setLayoutY(maDvY);
+      // Move the triangle to (maDvX, maDvY)
+      monsterRender.setLayoutX(maDvX);
+      monsterRender.setLayoutY(maDvY);
 
-    mapView.getChildren().add(testMonsterRepresentation);
-    Monster monster = gameMap.getMonsters().getFirst();
-    if (monster instanceof Mugger) {
-      testMonsterRepresentation.setFill(Color.RED);
-    } else if (monster instanceof Sniffer) {
-      testMonsterRepresentation.setFill(Color.YELLOW);
-    } else if (monster instanceof Lurker) {
-      testMonsterRepresentation.setFill(Color.ORCHID);
+      mapView.getChildren().add(monsterRender);
+      switch (monster) {
+        case Mugger ignored -> monsterRender.setFill(Color.RED);
+        case Sniffer ignored -> monsterRender.setFill(Color.YELLOW);
+        case Lurker ignored -> monsterRender.setFill(Color.ORCHID);
+        default -> log.warn("Unknown Monster added to game map, no render possible");
 
+      }
+      creaturesRepresentationMap.put(monster, monsterRender);
     }
-    creaturesRepresentationMap.put(gameMap.getMonsters().getFirst(), testMonsterRepresentation);
-    testMonsterRepresentation.setVisible(false);
 
     // Listener for facingDirection of Monsters
     for (Entry<Creature, Node> entry : creaturesRepresentationMap.entrySet()) {

--- a/src/main/java/game/adventurer/util/PathfindingUtil.java
+++ b/src/main/java/game/adventurer/util/PathfindingUtil.java
@@ -395,7 +395,7 @@ public class PathfindingUtil {
         }
       }
     }
-    log.info("CalculatedSearchArea size : {}", searchArea);
+    log.info("CalculatedSearchArea size : {}", searchArea.size());
     return searchArea;
   }
 


### PR DESCRIPTION
Monsters procedurally added to the map, depending on chosen DifficultyLevel and MapSize

- Monsters are only placed on tiles they can move onto, and all except Lurkers have to have a valid path to the Adventurer;
- they cannot start on a Tile where another monster is;
- the map is "split" into quadrants of 5*5 tiles so that no Monster is created directly near the Adventurer starting position AND Monsters should be evenly distributed as much as possible